### PR TITLE
Add reusable message templates

### DIFF
--- a/ApiClient.js
+++ b/ApiClient.js
@@ -1,8 +1,14 @@
 
+const templates = require('./messageTemplates');
+
 class ApiClient {
-  constructor(apiKey, messageLog) {
+  constructor(apiKey, messageLog, templateKey) {
     this.apiKey = apiKey;
     this.messageLog = messageLog;
+    this.template = templates[templateKey];
+    if (!this.template) {
+      throw new Error(`Unknown message template: ${templateKey}`);
+    }
   }
 
   async sendMessage(model) {
@@ -12,7 +18,7 @@ class ApiClient {
   }
 
   transformMessageLog(messageLog) {
-    throw new Error('transformMessageLog() must be implemented by subclasses');
+    return this.template(messageLog, this);
   }
 
   stripDocTagsIfOnlyOneSet(userContent) {

--- a/ApiClientAnthropic.js
+++ b/ApiClientAnthropic.js
@@ -3,7 +3,7 @@ const Anthropic = require('@anthropic-ai/sdk');
 
 class ApiClientAnthropic extends ApiClient {
   constructor(apiKey, messageLog) {
-    super(apiKey, messageLog);
+    super(apiKey, messageLog, 'anthropic');
     this.anthropic = new Anthropic({ apiKey: this.apiKey });
   }
 
@@ -39,39 +39,7 @@ class ApiClientAnthropic extends ApiClient {
     return response.content[0].text;
   }
 
-  transformMessageLog(rawMessageLog) {
-    let transformedMessageLog = [];
-    let userContent = '';
-
-    for (let i = 0; i < rawMessageLog.length; i++) {
-      let message = rawMessageLog[i];
-      if (message.role === 'user') {
-        userContent += `<doc>${message.content}</doc>`;
-      } 
-      else {
-        if (userContent) {
-          transformedMessageLog.push({
-            role: 'user',
-            content: this.stripDocTagsIfOnlyOneSet(userContent)
-          });
-          userContent = '';
-        }
-        transformedMessageLog.push({
-          role: 'assistant',
-          content: message.content
-        });
-      }
-    }
-
-    // if the last message was a user message, add it to the transformed message log
-    if (userContent) {
-      transformedMessageLog.push({
-        role: 'user',
-        content: this.stripDocTagsIfOnlyOneSet(userContent)
-      });
-    }
-    return transformedMessageLog;
-  }
+  // message transformation handled by base class template
 }
 
 module.exports = ApiClientAnthropic;

--- a/ApiClientGoogle.js
+++ b/ApiClientGoogle.js
@@ -3,7 +3,7 @@ const { GoogleGenerativeAI } = require("@google/generative-ai");
 
 class ApiClientGoogle extends ApiClient {
   constructor(apiKey, messageLog) {
-    super(apiKey, messageLog);
+    super(apiKey, messageLog, 'google');
     this.google = new GoogleGenerativeAI(this.apiKey);
   }
 
@@ -53,46 +53,7 @@ class ApiClientGoogle extends ApiClient {
     }
   }
 
-  transformMessageLog(rawMessageLog) {
-    let transformedMessageLog = [];
-    let userContent = '';
-
-    for (let i = 0; i < rawMessageLog.length; i++) {
-      let message = rawMessageLog[i];
-
-      if (message.role === 'user') {
-        userContent += `<doc>${message.content}</doc>`;
-      }
-      else {
-        if (userContent) {
-          transformedMessageLog.push({
-            role: 'user',
-            parts: [{ text: this.stripDocTagsIfOnlyOneSet(userContent) }]
-          });
-          userContent = '';
-        }
-        transformedMessageLog.push({
-          role: 'model',
-          parts: [{ text: message.content }]
-        });
-      }
-    }
-
-    // if the last message was a user message, add it to the transformed message log
-    if (userContent) {
-      transformedMessageLog.push({
-        role: 'user',
-        parts: [{ text: this.stripDocTagsIfOnlyOneSet(userContent) }]
-      });
-    }
-    
-    // Add a continue message
-    transformedMessageLog.push({
-      role: 'model',
-      parts: [{ text: 'continue' }]
-    });
-    return transformedMessageLog;
-  }
+  // message transformation handled by base class template
 
   getLastUserMessage(messageLog) {
     for (let i = messageLog.length - 1; i >= 0; i--) {

--- a/ApiClientMistral.js
+++ b/ApiClientMistral.js
@@ -2,7 +2,7 @@ const ApiClient = require('./ApiClient');
 
 class ApiClientMistral extends ApiClient {
   constructor(apiKey, messageLog) {
-    super(apiKey, messageLog);
+    super(apiKey, messageLog, 'mistral');
   }
 
   async sendMessage(model) {
@@ -38,41 +38,7 @@ class ApiClientMistral extends ApiClient {
     return response.choices[0].message.content;
   }
 
-  transformMessageLog(rawMessageLog) {
-    let transformedMessageLog = [];
-    let userContent = '';
-
-    for (let i = 0; i < rawMessageLog.length; i++) {
-      let message = rawMessageLog[i];
-
-      if (message.role === 'user') {
-        userContent += `<doc>${message.content}</doc>`;
-      }
-      else {
-        if (userContent) {
-          transformedMessageLog.push({
-            role: 'user',
-            content: userContent
-          });
-          userContent = '';
-        }
-        transformedMessageLog.push({
-          role: 'assistant',
-          content: message.content
-        });
-      }
-    }
-
-    // if the last message was a user message, add it to the transformed message log
-    if (userContent) {
-      transformedMessageLog.push({
-        role: 'user',
-        content: userContent
-      });
-    }
-
-    return transformedMessageLog;
-  }
+  // message transformation handled by base class template
 }
 
 module.exports = ApiClientMistral;

--- a/ApiClientOllama.js
+++ b/ApiClientOllama.js
@@ -3,7 +3,7 @@ const axios = require('axios');
 
 class ApiClientOllama extends ApiClient {
   constructor(apiKey, messageLog) {
-    super(apiKey, messageLog);
+    super(apiKey, messageLog, 'ollama');
     this.baseURL = process.env.OLLAMA_API_URL || 'http://127.0.0.1:11434';
     const headers = { 'Content-Type': 'application/json' };
     if (this.apiKey) {
@@ -30,15 +30,7 @@ class ApiClientOllama extends ApiClient {
     return response.data.choices[0].message.content;
   }
 
-  transformMessageLog(rawMessageLog) {
-    return rawMessageLog.map(message => {
-      const role = message.role === 'model' ? 'assistant' : message.role;
-      return {
-        role,
-        content: message.content
-      };
-    });
-  }
+  // message transformation handled by base class template
 
   // Fetch available models from Ollama server
   async listModels() {

--- a/ApiClientOpenAI.js
+++ b/ApiClientOpenAI.js
@@ -3,7 +3,7 @@ const OpenAI = require('openai');
 
 class ApiClientOpenAI extends ApiClient {
   constructor(apiKey, messageLog) {
-    super(apiKey, messageLog);
+    super(apiKey, messageLog, 'openai');
     this.openai = new OpenAI({ apiKey: this.apiKey });
   }
 
@@ -46,31 +46,7 @@ class ApiClientOpenAI extends ApiClient {
     return response.choices[0].message.content;
   }
 
-  transformMessageLog(rawMessageLog) {
-    // Transform the raw message log into the format expected
-    return rawMessageLog.map(message => {
-      // If the role is model, change it to assistant
-      const role = message.role === 'model' ? 'assistant' : message.role;
-
-      let content = [];
-      if (message.type === 'text') {
-        content = [{
-          type: message.type,
-          text: message.content
-        }];
-      }
-      else if (message.type === 'image') {
-        content = [{
-          type: 'image_url',
-          image_url: {
-            url: message.content
-          }
-        }];
-      }
-      
-      return { role, content };
-    });
-  }
+  // message transformation handled by base class template
 }
 
 module.exports = ApiClientOpenAI;

--- a/ApiClientPerplexity.js
+++ b/ApiClientPerplexity.js
@@ -3,7 +3,7 @@ const OpenAI = require('openai');
 
 class ApiClientPerplexity extends ApiClient {
   constructor(apiKey, messageLog) {
-    super(apiKey, messageLog);
+    super(apiKey, messageLog, 'perplexity');
     this.baseURL = "https://api.perplexity.ai";
     this.openai = new OpenAI({ baseURL: this.baseURL, apiKey: this.apiKey });
   }
@@ -36,60 +36,7 @@ class ApiClientPerplexity extends ApiClient {
     return response.choices[0].message.content;
   }
 
-  transformMessageLog(rawMessageLog) {
-    let transformedMessageLog = [];
-    let userContent = '';
-
-    for (let i = 0; i < rawMessageLog.length; i++) {
-      let message = rawMessageLog[i];
-
-      if (message.role === 'user') {
-        userContent += message.content;
-      }
-      else {
-        if (userContent) {
-          transformedMessageLog.push({
-            role: 'user',
-            content: [{
-              type: 'text',
-              text: userContent
-            }]
-          });
-          userContent = '';
-        }
-        transformedMessageLog.push({
-          role: 'assistant',
-          content: [{ 
-            type: message.type,
-            text: message.content 
-          }]
-        });
-      }
-    }
-
-    // if the last message was a user message, add it to the transformed message log
-    if (userContent) {
-      transformedMessageLog.push({
-        role: 'user',
-        content: [{
-          type: 'text',
-          text: userContent
-        }]
-      });
-    }
-
-    // Add a continue message
-    //transformedMessageLog.push({
-    //  role: 'assistant',
-    //  content: [{ 
-    //    type: 'text',
-    //    text: 'continue' 
-    //  }]
-    //});
-    
-    //console.log(JSON.stringify(transformedMessageLog, null, 2));
-    return transformedMessageLog;
-  }
+  // message transformation handled by base class template
 }
 
 module.exports = ApiClientPerplexity;

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ The first letter can be used as a shortcut for each command. Paths can be relati
 - **Anthropic**: https://docs.anthropic.com/claude/reference/getting-started-with-the-api
 - **Mistral AI**: https://docs.mistral.ai/#api-access
 
+### Message Templates
+
+Message formatting rules for each provider are defined in `messageTemplates.js`.
+Api clients automatically load the correct template, so you can customize how
+messages are sent by editing that file.
+
 ## Configuration
 
 Copy `.env.example` to `.env` and fill in your API keys. The application uses the [dotenv](https://www.npmjs.com/package/dotenv) package to load variables automatically:

--- a/messageTemplates.js
+++ b/messageTemplates.js
@@ -1,0 +1,125 @@
+const templates = {
+  openai(rawLog, client) {
+    return rawLog.map(message => {
+      const role = message.role === 'model' ? 'assistant' : message.role;
+      let content = [];
+      if (message.type === 'text') {
+        content = [{ type: message.type, text: message.content }];
+      } else if (message.type === 'image') {
+        content = [{ type: 'image_url', image_url: { url: message.content } }];
+      }
+      return { role, content };
+    });
+  },
+
+  anthropic(rawLog, client) {
+    let transformed = [];
+    let userContent = '';
+    for (const message of rawLog) {
+      if (message.role === 'user') {
+        userContent += `<doc>${message.content}</doc>`;
+      } else {
+        if (userContent) {
+          transformed.push({
+            role: 'user',
+            content: client.stripDocTagsIfOnlyOneSet(userContent)
+          });
+          userContent = '';
+        }
+        transformed.push({ role: 'assistant', content: message.content });
+      }
+    }
+    if (userContent) {
+      transformed.push({
+        role: 'user',
+        content: client.stripDocTagsIfOnlyOneSet(userContent)
+      });
+    }
+    return transformed;
+  },
+
+  google(rawLog, client) {
+    let transformed = [];
+    let userContent = '';
+    for (const message of rawLog) {
+      if (message.role === 'user') {
+        userContent += `<doc>${message.content}</doc>`;
+      } else {
+        if (userContent) {
+          transformed.push({
+            role: 'user',
+            parts: [{ text: client.stripDocTagsIfOnlyOneSet(userContent) }]
+          });
+          userContent = '';
+        }
+        transformed.push({ role: 'model', parts: [{ text: message.content }] });
+      }
+    }
+    if (userContent) {
+      transformed.push({
+        role: 'user',
+        parts: [{ text: client.stripDocTagsIfOnlyOneSet(userContent) }]
+      });
+    }
+    transformed.push({ role: 'model', parts: [{ text: 'continue' }] });
+    return transformed;
+  },
+
+  mistral(rawLog) {
+    let transformed = [];
+    let userContent = '';
+    for (const message of rawLog) {
+      if (message.role === 'user') {
+        userContent += `<doc>${message.content}</doc>`;
+      } else {
+        if (userContent) {
+          transformed.push({ role: 'user', content: userContent });
+          userContent = '';
+        }
+        transformed.push({ role: 'assistant', content: message.content });
+      }
+    }
+    if (userContent) {
+      transformed.push({ role: 'user', content: userContent });
+    }
+    return transformed;
+  },
+
+  perplexity(rawLog) {
+    let transformed = [];
+    let userContent = '';
+    for (const message of rawLog) {
+      if (message.role === 'user') {
+        userContent += message.content;
+      } else {
+        if (userContent) {
+          transformed.push({
+            role: 'user',
+            content: [{ type: 'text', text: userContent }]
+          });
+          userContent = '';
+        }
+        transformed.push({
+          role: 'assistant',
+          content: [{ type: message.type, text: message.content }]
+        });
+      }
+    }
+    if (userContent) {
+      transformed.push({
+        role: 'user',
+        content: [{ type: 'text', text: userContent }]
+      });
+    }
+    return transformed;
+  },
+
+  ollama(rawLog) {
+    return rawLog.map(message => {
+      const role = message.role === 'model' ? 'assistant' : message.role;
+      return { role, content: message.content };
+    });
+  }
+};
+
+module.exports = templates;

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.12.4",
     "@google/generative-ai": "^0.16.0",

--- a/test/messageTemplates.test.js
+++ b/test/messageTemplates.test.js
@@ -1,0 +1,70 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const ApiClient = require('../ApiClient');
+
+const sampleLog = [
+  { role: 'user', type: 'text', content: 'Hello' },
+  { role: 'model', type: 'text', content: 'Hi' },
+  { role: 'user', type: 'text', content: 'How are you?' }
+];
+
+test('openai template', () => {
+  const client = new ApiClient('', null, 'openai');
+  const result = client.transformMessageLog(sampleLog);
+  assert.deepStrictEqual(result, [
+    { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+    { role: 'assistant', content: [{ type: 'text', text: 'Hi' }] },
+    { role: 'user', content: [{ type: 'text', text: 'How are you?' }] }
+  ]);
+});
+
+test('anthropic template', () => {
+  const client = new ApiClient('', null, 'anthropic');
+  const result = client.transformMessageLog(sampleLog);
+  assert.deepStrictEqual(result, [
+    { role: 'user', content: 'Hello' },
+    { role: 'assistant', content: 'Hi' },
+    { role: 'user', content: 'How are you?' }
+  ]);
+});
+
+test('google template', () => {
+  const client = new ApiClient('', null, 'google');
+  const result = client.transformMessageLog(sampleLog);
+  assert.deepStrictEqual(result, [
+    { role: 'user', parts: [{ text: 'Hello' }] },
+    { role: 'model', parts: [{ text: 'Hi' }] },
+    { role: 'user', parts: [{ text: 'How are you?' }] },
+    { role: 'model', parts: [{ text: 'continue' }] }
+  ]);
+});
+
+test('mistral template', () => {
+  const client = new ApiClient('', null, 'mistral');
+  const result = client.transformMessageLog(sampleLog);
+  assert.deepStrictEqual(result, [
+    { role: 'user', content: '<doc>Hello</doc>' },
+    { role: 'assistant', content: 'Hi' },
+    { role: 'user', content: '<doc>How are you?</doc>' }
+  ]);
+});
+
+test('perplexity template', () => {
+  const client = new ApiClient('', null, 'perplexity');
+  const result = client.transformMessageLog(sampleLog);
+  assert.deepStrictEqual(result, [
+    { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+    { role: 'assistant', content: [{ type: 'text', text: 'Hi' }] },
+    { role: 'user', content: [{ type: 'text', text: 'How are you?' }] }
+  ]);
+});
+
+test('ollama template', () => {
+  const client = new ApiClient('', null, 'ollama');
+  const result = client.transformMessageLog(sampleLog);
+  assert.deepStrictEqual(result, [
+    { role: 'user', content: 'Hello' },
+    { role: 'assistant', content: 'Hi' },
+    { role: 'user', content: 'How are you?' }
+  ]);
+});


### PR DESCRIPTION
## Summary
- centralize message formatting logic in new `messageTemplates.js`
- load templates in `ApiClient` and remove per-client implementations
- adapt all API client classes to pass a template key
- add a basic test suite covering each template
- document message templates in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683c5db19494832991172884c058ebb5