### PR TITLE
Use pdfjs-dist for PDF text extraction

### DIFF
--- a/Extractor.js
+++ b/Extractor.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const isUtf8 = require('is-utf8');
-const pdfParse = require('pdf-parse');
+const pdfjsLib = require('pdfjs-dist/legacy/build/pdf.js');
 const { PDFDocument, PDFName, PDFRawStream } = require('pdf-lib');
 const pathModule = require('path');
 const pako = require('pako');
@@ -53,10 +53,17 @@ class Extractor {
 
   async extractTextFromPdf(path) {
     try {
-      const dataBuffer = fs.readFileSync(path);
-      const data = await pdfParse(dataBuffer);
-      //console.log(data.text);
-      return data.text;
+      const data = new Uint8Array(fs.readFileSync(path));
+      const pdf = await pdfjsLib.getDocument({ data }).promise;
+      let text = '';
+      const numPages = pdf.numPages;
+      for (let i = 1; i <= numPages; i++) {
+        const page = await pdf.getPage(i);
+        const content = await page.getTextContent({ normalizeWhitespace: true });
+        const strings = content.items.map(item => item.str);
+        text += strings.join(' ') + '\n';
+      }
+      return text;
     } catch (error) {
       throw new Error(`\nFailed to extract text from PDF: ${error.message}\n`);
     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ora": "^7.0.1",
     "pako": "^1.0.11",
     "pdf-lib": "^1.17.1",
-    "pdf-parse": "^1.1.1",
+    "pdfjs-dist": "^3.11.174",
     "punycode": "^2.3.1",
     "puppeteer": "^22.7.1",
     "puppeteer-extra": "^3.3.6",


### PR DESCRIPTION
## Summary
- process PDF text using `pdfjs-dist` with whitespace normalization

## Testing
- `npm test` *(fails: ollama template assertion)*

------
https://chatgpt.com/codex/tasks/task_b_683c747480b883298330259ebf7ba981