### PR TITLE
Add pdf extension lookup

### DIFF
--- a/ProcessorData.js
+++ b/ProcessorData.js
@@ -23,7 +23,14 @@ class DataProcessor extends Processor {
       case 'git': case 'g':
       case 'web': case 'w':
         this.path = await this.getUserInput('\nEnter path: \n');
-        if (!this.path.startsWith('http')) this.path = pathModule.resolve(this.path);
+        if (!this.path.startsWith('http')) {
+          this.path = pathModule.resolve(this.path);
+          if ((input === 'pdf' || input === 'p') &&
+              !this.path.toLowerCase().endsWith('.pdf')) {
+            const pdfPath = this.path + '.pdf';
+            if (fs.existsSync(pdfPath)) this.path = pdfPath;
+          }
+        }
         this.chatSession.appendMessageToFile('\n\n***\n\n### User:\n\n' + this.path);
         break;
       default:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Follow the prompts to input commands and paths to data sources. The application 
 The first letter can be used as a shortcut for each command. Paths can be relative, absolute, or URLs.
 
 - `file`: Process a text file.
-- `pdf`: Process a PDF file.
+- `pdf`: Process a PDF file. If a local path without the `.pdf` extension is
+  provided, the extension will be checked automatically.
 - `xlsx`: Process an Excel file.
 - `image`: Process an image URL.
 - `dir`: Process a directory.


### PR DESCRIPTION
## Summary
- automatically add `.pdf` extension when needed for PDF files
- document pdf extension lookup

## Testing
- `npm test` *(fails: perplexity template, ollama template)*

------
https://chatgpt.com/codex/tasks/task_b_683ca75f9c7083299bf78d0ebef6e72c